### PR TITLE
Lobby backend (#42)

### DIFF
--- a/gnome-party_backend/Models/CombatData/CombatEncounter.cs
+++ b/gnome-party_backend/Models/CombatData/CombatEncounter.cs
@@ -1,4 +1,5 @@
-﻿using Models.CharacterData;
+﻿using Amazon.DynamoDBv2.DataModel;
+using Models.CharacterData;
 using Models.CharacterData.EasyEnemyPoolClasses;
 using Models.EncounterData;
 
@@ -20,6 +21,6 @@ public class CombatEncounter : Encounter
     public CombatEncounter(List<Character> _enemies)
     {
         Enemies = _enemies;
-    }   
+    }
     public List<Character> Enemies { get; set; }
 }

--- a/gnome-party_backend/Models/EncounterConverter.cs
+++ b/gnome-party_backend/Models/EncounterConverter.cs
@@ -1,0 +1,45 @@
+﻿using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.DocumentModel;
+using Models.CombatData;
+using Models.EncounterData;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Models;
+
+public class EncounterConverter : IPropertyConverter
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        // Embeds "$type" field so polymorphic types survive round-trips
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
+        WriteIndented = false
+    };
+
+    public DynamoDBEntry ToEntry(object value)
+    {
+        if (value is not Encounter encounter)
+            throw new ArgumentException("Expected an Encounter");
+
+        string json = JsonSerializer.Serialize(encounter, typeof(Encounter), Options);
+        return new Primitive(json);
+    }
+
+    public object FromEntry(DynamoDBEntry entry)
+    {
+        string json = entry.AsString();
+        var encounter = JsonSerializer.Deserialize<Encounter>(json, Options)
+               ?? throw new InvalidOperationException("Failed to deserialize Encounter");
+        if (encounter is CombatEncounter)
+        {
+            return encounter as CombatEncounter;
+        }
+        else
+        {
+            return encounter;
+        }
+    }
+}

--- a/gnome-party_backend/Models/EncounterData/Encounter.cs
+++ b/gnome-party_backend/Models/EncounterData/Encounter.cs
@@ -1,7 +1,15 @@
-﻿namespace Models.EncounterData;
+﻿using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.DocumentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
+namespace Models.EncounterData;
+
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "$type")]
+[JsonDerivedType(typeof(Models.CombatData.CombatEncounter), typeDiscriminator: "CombatEncounter")]
 public class Encounter
 {
     public int ActionTime { get; set; } = 10;
-   public Encounter(){}
+    public Encounter(){}
 }

--- a/gnome-party_backend/Models/EncounterListConverter.cs
+++ b/gnome-party_backend/Models/EncounterListConverter.cs
@@ -1,0 +1,27 @@
+﻿using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.DocumentModel;
+using Models.EncounterData;
+
+namespace Models;
+
+public class EncounterListConverter : IPropertyConverter
+{
+    private static readonly EncounterConverter Inner = new();
+
+    public DynamoDBEntry ToEntry(object value)
+    {
+        var encounters = (List<Encounter>)value;
+        var list = new DynamoDBList();
+        foreach (var encounter in encounters)
+            list.Add(Inner.ToEntry(encounter));
+        return list;
+    }
+
+    public object FromEntry(DynamoDBEntry entry)
+    {
+        var list = (DynamoDBList)entry;
+        return list.Entries
+            .Select(e => (Encounter)Inner.FromEntry(e))
+            .ToList();
+    }
+}

--- a/gnome-party_backend/Models/GameMetaData/Campaign.cs
+++ b/gnome-party_backend/Models/GameMetaData/Campaign.cs
@@ -1,15 +1,72 @@
-﻿using Models.CharacterData;
+﻿using Amazon.DynamoDBv2.DataModel;
+using Models.CharacterData;
+using Models.CharacterData.EasyEnemyPoolClasses;
 using Models.CombatData;
+using Models.EncounterData;
+
 
 namespace Models.GameMetaData;
 
 public class Campaign
 {
-    public List<CombatEncounter> Encounters { get; set; }
+    [DynamoDBProperty(typeof(EncounterListConverter))]
+    public List<Encounter> Encounters { get; set; }
     public List<Character> PlayerCharacters { get; set; }
+    public int CurrentEncounterIndex { get; set; } = 0;
     public Campaign()
     {
         PlayerCharacters = new List<Character>();
-        Encounters = [new CombatEncounter()];
+        Encounters = [];
+    }
+
+    public void InitEncounters()
+    {
+        //Change later: right now every pool will have the same number of encounters included, but eventually we may want to have different numbers of encounters from each pool
+        int numberOfEncountersToIncludePerPool = 2;
+        List<List<Encounter>> encounterPools = [
+            // easy pool
+            [
+                new CombatEncounter
+                {
+                    Enemies = [
+                        new Skeleton()
+                        {
+                            Health = 10,
+                            MaxHealth = 10,
+                        },
+                        new Skeleton()
+                    ]
+                },
+                new CombatEncounter
+                {
+                    Enemies = [
+                        new Skeleton()
+                        {
+                            Health = 30,
+                            MaxHealth = 30,
+                        }
+                    ]
+                }
+            ],
+            // medium pool
+            [
+                new CombatEncounter
+                {
+                    Enemies = [
+                        new Skeleton()
+                        {
+                            Health = 15,
+                            MaxHealth = 15,
+                        }
+                    ]
+                }
+            ]
+        ];
+
+        foreach (var pool in encounterPools)
+        {
+            var radomOrderedPool = pool.Shuffle();
+            Encounters.AddRange(radomOrderedPool.Take(numberOfEncountersToIncludePerPool));
+        }
     }
 }

--- a/gnome-party_backend/Models/GameMetaData/GameSession.cs
+++ b/gnome-party_backend/Models/GameMetaData/GameSession.cs
@@ -20,32 +20,35 @@ public class GameSession
         GameSessionId = Guid.NewGuid().ToString();
         Host = _host;
         Participants = new List<GameConnection>();
-        InviteCode = 0;
+        InviteCode = Random.Shared.Next(100000, 1000000); //random 6 digit code
         Campaign = new Campaign();
     }
     public List<GameConnection> Participants { get; set; }
     public void AddParticipant(GameConnection connection)
     {
         Participants.Add(connection);
-        var character = new Character(connection.UserId);
+    }
+    public void AddPlayerCharacter(Character character)
+    {
         Campaign.PlayerCharacters.Add(character);
     }
-    public void AddParticipant(string connectionId, string userId)
-    {
-        var connection = new GameConnection(connectionId, userId, GameSessionId);
-        AddParticipant(connection);
-    }
+
     public void RemoveParticipant(string connectionId)
     {
         var connection = Participants.FirstOrDefault(c => c.ConnectionId == connectionId);
         if (connection != null)
         {
             Participants.Remove(connection);
-            var character = Campaign.PlayerCharacters.FirstOrDefault(pc => pc.Id == connection.UserId);
-            if (character != null)
-            {
-                Campaign.PlayerCharacters.Remove(character);
-            }
+            RemovePlayerCharacter(connectionId);
+        }
+    }
+
+    public void RemovePlayerCharacter(string characterId)
+    {
+        var character = Campaign.PlayerCharacters.FirstOrDefault(pc => pc.Id == characterId);
+        if (character != null)
+        {
+            Campaign.PlayerCharacters.Remove(character);
         }
     }
 }

--- a/gnome-party_backend/Models/LobbyReadyRequest.cs
+++ b/gnome-party_backend/Models/LobbyReadyRequest.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Models;
+
+public class LobbyReadyRequest
+{
+    public string CharacterType { get; set; } = "";
+
+    //in future add character customizations here
+}

--- a/gnome-party_backend/SocketService/Functions.cs
+++ b/gnome-party_backend/SocketService/Functions.cs
@@ -1,17 +1,20 @@
+using Amazon;
 using Amazon.ApiGatewayManagementApi;
 using Amazon.ApiGatewayManagementApi.Model;
 using Amazon.DynamoDBv2;
 using Amazon.Lambda.APIGatewayEvents;
 using Amazon.Lambda.Core;
+using CombatService;
+using GnomeParty.Database;
+using Models;
+using Models.CharacterData;
+using Models.CharacterData.PlayerCharacterClasses;
+using Models.CombatData;
+using Models.EncounterData;
+using Models.GameMetaData;
 using System.Net;
 using System.Text;
 using System.Text.Json;
-using GnomeParty.Database;
-using CombatService;
-using Amazon;
-using Models.CombatData;
-using Models.GameMetaData;
-using Models.EncounterData;
 
 // Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
 [assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
@@ -153,8 +156,8 @@ public class Functions
     //{"route": "begin-combat-encounter", "GameSessionId": ""}
     public async Task<APIGatewayProxyResponse> BeginCombatEncounterHandler(APIGatewayProxyRequest request, ILambdaContext context)
     {
-        // example message body to trigger this route
-        //{"route": "begin-combat-encounter", "GameSessionId": "f4477afa-a9e8-48fc-9dcc-60e7ac64ac3b"}
+        //since connections now contain GameSessionId, this route could be rewrittent to get rid of the GameSessionId param
+        // and instead pull the game session id from the connection info in the database.
         // ripped most of this Json parsing code from WebSocket sample at https://github.com/aws/aws-lambda-dotnet/blob/master/Blueprints/BlueprintDefinitions/vs2026/WebSocketAPIServerless/template/src/BlueprintBaseName.1/Functions.cs
         JsonDocument message = JsonDocument.Parse(request.Body);
 
@@ -175,17 +178,21 @@ public class Functions
         Console.WriteLine($"After load");
         Console.WriteLine($"Game session is {JsonSerializer.Serialize(gameSession)}");
 
+        var currentEncounter = gameSession.Campaign.Encounters[gameSession.Campaign.CurrentEncounterIndex];
+        var tasks = new List<Task>();
+        Console.WriteLine(currentEncounter.GetType().Name);
+        if (currentEncounter is CombatEncounter)
+        {
+            var activeEncounter = new ActiveCombatEncounter(gameSession.Campaign.PlayerCharacters, (currentEncounter as CombatEncounter).Enemies);
+            Console.WriteLine($"Active encounter: {JsonSerializer.Serialize(activeEncounter)}");
+            tasks.Add(databaseService.SaveAsync(activeEncounter));
+            tasks.Add(BroadcastToConnectionAsync(gameSession, request, new ConnectionMessage("begin-combat-encounter", activeEncounter)));
+        }
+
         var connectionId = request.RequestContext.ConnectionId;
-
-        var activeEncounter = new ActiveCombatEncounter(gameSession.Campaign.PlayerCharacters, gameSession.Campaign.Encounters[0].Enemies);
-        Console.WriteLine($"Pre save");
-        Console.WriteLine($"Active encounter: {JsonSerializer.Serialize(activeEncounter)}");
-
-        await databaseService.SaveAsync(activeEncounter);
-        Console.WriteLine($"After save");
-
-        await BroadcastToConnectionAsync(gameSession, request, new ConnectionMessage("begin-combat-encounter", activeEncounter));
-
+        gameSession.Campaign.CurrentEncounterIndex++;
+        tasks.Add(databaseService.SaveAsync(gameSession));
+        await Task.WhenAll(tasks);
 
         return new APIGatewayProxyResponse
         {
@@ -194,7 +201,7 @@ public class Functions
         };
     }
 
-    //{"route":"join-game"}
+    //{"route":"join-game", "InviteCode":849175}
     public async Task<APIGatewayProxyResponse> JoinGameSessionHandler(APIGatewayProxyRequest request, ILambdaContext context)
     {
         try
@@ -210,25 +217,50 @@ public class Functions
             context.Logger.LogInformation($"Body: {request.Body}");
 
             var databaseService = new DatabaseService();
+            JsonDocument message = JsonDocument.Parse(request.Body);
+            //var inviteCode = message.Deserialize<int>();
+            //Console.WriteLine($"Invite code: {inviteCode}");
 
+            JsonElement inviteCodeJsonElement;
+            if (!message.RootElement.TryGetProperty("InviteCode", out inviteCodeJsonElement))
+            {
+                context.Logger.LogInformation("Could not find InviteCode in input");
+                return new APIGatewayProxyResponse
+                {
+                    StatusCode = (int)HttpStatusCode.BadRequest
+                };
+            }
+            var inviteCode = inviteCodeJsonElement.GetInt32();
             GameSession gameSession;
-            gameSession = await databaseService.GetGameSessionByInviteCodeAsync(0);
+            try
+            {
+                gameSession = await databaseService.GetGameSessionByInviteCodeAsync(inviteCode);
+            }
+            catch (KeyNotFoundException)
+            {
+                context.Logger.LogInformation($"No game session found with invite code {inviteCode}");
+                await SendToConnectionAsync(connectionId, request, new ConnectionMessage("join-game-session-failed", $"No game session found with invite code {inviteCode}"));
+                return new APIGatewayProxyResponse
+                {
+                    StatusCode = (int)HttpStatusCode.NotFound,
+                    Body = $"No game session found with invite code {inviteCode}"
+                };
+            }
             context.Logger.LogInformation("Loaded existing game session");
             var playerId = CreateNewPlayerId();
             var connection = new GameConnection(connectionId, playerId, gameSession);
 
             gameSession.AddParticipant(connection);
 
-            await databaseService.SaveAsync(connection);
-            context.Logger.LogInformation("Saved connection");
-
-            await databaseService.SaveAsync(gameSession);
-            context.Logger.LogInformation("Saved game session");
-
-            await SendToConnectionAsync(connectionId, request, new ConnectionMessage("join-game-connection", connection));
-            await SendToConnectionAsync(connectionId, request, new ConnectionMessage("join-game-session", gameSession));
-            context.Logger.LogInformation("Sent game session to connection");
-
+            var tasks = new List<Task>
+            {
+                databaseService.SaveAsync(connection),
+                 databaseService.SaveAsync(gameSession),
+                 SendToConnectionAsync(connectionId, request, new ConnectionMessage("join-game-connection", connection)),
+                 SendToConnectionAsync(connectionId, request, new ConnectionMessage("join-game-session", gameSession)),
+            };
+            await Task.WhenAll(tasks);
+            
             return new APIGatewayProxyResponse
             {
                 StatusCode = (int)HttpStatusCode.OK,
@@ -248,7 +280,7 @@ public class Functions
         }
     }
 
-    //{"route":"join-game"}
+    //{"route":"host-game"}
     public async Task<APIGatewayProxyResponse> HostGameSessionHandler(APIGatewayProxyRequest request, ILambdaContext context)
     {
         try
@@ -257,14 +289,23 @@ public class Functions
 
             var databaseService = new DatabaseService();
 
-            //deleting all the game sessions is temporary, because all games have the same invite code
-            //and we want keep it that way for now so participants can easily find the host. In the future we will want to generate unique invite codes for each game and remove this line
-            await databaseService.DeleteAllEntriesFromTableAsync<GameSession>();
-
             var playerId = CreateNewPlayerId();
             var connection = new GameConnection(connectionId, playerId);
             var gameSession = new GameSession(connection);
             connection.GameSessionId = gameSession.GameSessionId;
+            while (true)
+            {
+                try
+                {
+                    await databaseService.GetGameSessionByInviteCodeAsync(gameSession.InviteCode); //will throw error if no game session with this code, disregard return value, just want to check if it exists 
+                    context.Logger.LogInformation($"Generated invite code {gameSession.InviteCode} already exists. Generating a new code.");
+                    gameSession.InviteCode = new Random().Next(100000, 1000000);//generate a new 6 digit code
+                }
+                catch (KeyNotFoundException) //strangely, if it throws this error, that means there is no existing game session with the same invite code, which is what we want
+                { 
+                    break;
+                }
+            }
 
             await databaseService.SaveAsync(connection);
             await databaseService.SaveAsync(gameSession);
@@ -287,6 +328,134 @@ public class Functions
         }
     }
 
+    //{"route":"lobby-ready", "CharacterType":"Mage"}
+    public async Task<APIGatewayProxyResponse> LobbyParticipantReadyHandler(APIGatewayProxyRequest request, ILambdaContext context)
+    {
+        try
+        {
+            var connectionId = request.RequestContext.ConnectionId;
+
+            var databaseService = new DatabaseService();
+
+            JsonDocument message = JsonDocument.Parse(request.Body);
+            var lobbyReadyRequest = message.Deserialize<LobbyReadyRequest>();
+
+            var connection = await databaseService.LoadAsync<GameConnection>(connectionId);
+            var gameSession = await databaseService.LoadAsync<GameSession>(connection.GameSessionId);
+
+            Character character = lobbyReadyRequest!.CharacterType switch
+            {
+                "Mage" => new Mage(),
+                "Warrior" => new Warrior(),
+                _ => throw new ArgumentException($"Unknown character type: {lobbyReadyRequest.CharacterType}")
+
+            };
+
+            gameSession.AddPlayerCharacter(character);
+
+            var tasks = new List<Task>
+            {
+                databaseService.SaveAsync(gameSession),
+                SendToConnectionAsync(connectionId, request, new ConnectionMessage("lobby-ready-success", character)),
+                SendToConnectionAsync(gameSession.Host.ConnectionId, request, new ConnectionMessage("lobby-ready", character))
+            };
+            await Task.WhenAll(tasks);
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = (int)HttpStatusCode.OK,
+                Body = "all good"
+            };
+        }
+        catch (Exception e)
+        {
+            context.Logger.LogInformation("LobbyParticipantReadyHandler failed: " + e.Message);
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = (int)HttpStatusCode.InternalServerError,
+                Body = $"Failed to ready up: {e.Message}"
+            };
+        }
+    }
+
+    //{"route":"lobby-unready"}
+    public async Task<APIGatewayProxyResponse> LobbyParticipantUnreadyHandler(APIGatewayProxyRequest request, ILambdaContext context)
+    {
+        try
+        {
+            var connectionId = request.RequestContext.ConnectionId;
+
+            var databaseService = new DatabaseService();
+
+            var connection = await databaseService.LoadAsync<GameConnection>(connectionId);
+            var gameSession = await databaseService.LoadAsync<GameSession>(connection.GameSessionId);
+
+            gameSession.RemovePlayerCharacter(connectionId);
+
+            var tasks = new List<Task>
+            {
+                databaseService.SaveAsync(gameSession),
+                SendToConnectionAsync(connectionId, request, new ConnectionMessage("lobby-unready-success", "")),
+                SendToConnectionAsync(gameSession.Host.ConnectionId, request, new ConnectionMessage("lobby-unready", connection))
+            };
+            await Task.WhenAll(tasks);
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = (int)HttpStatusCode.OK,
+                Body = "all good"
+            };
+        }
+        catch (Exception e)
+        {
+            context.Logger.LogInformation("LobbyParticipantUnreadyHandler failed: " + e.Message);
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = (int)HttpStatusCode.InternalServerError,
+                Body = $"Failed to unready up: {e.Message}"
+            };
+        }
+    }
+
+    //{"route":"start-campaign"}
+    public async Task<APIGatewayProxyResponse> StartCampaignHandler(APIGatewayProxyRequest request, ILambdaContext context)
+    {
+        try
+        {
+            var connectionId = request.RequestContext.ConnectionId;
+
+            var databaseService = new DatabaseService();
+
+            var connection = await databaseService.LoadAsync<GameConnection>(connectionId);
+            var gameSession = await databaseService.LoadAsync<GameSession>(connection.GameSessionId);
+            gameSession.Campaign.InitEncounters();
+
+            Console.WriteLine($"Game session post init is {JsonSerializer.Serialize(gameSession)}");
+
+            var tasks = new List<Task>
+            {
+                databaseService.SaveAsync(gameSession),
+                BroadcastToConnectionAsync(gameSession, request, new ConnectionMessage("start-campaign", gameSession))
+            };
+            await Task.WhenAll(tasks);
+
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = (int)HttpStatusCode.OK,
+                Body = "all good"
+            };
+        }
+        catch (Exception e)
+        {
+            context.Logger.LogInformation("StartCampaignHandler failed: " + e.Message);
+            return new APIGatewayProxyResponse
+            {
+                StatusCode = (int)HttpStatusCode.InternalServerError,
+                Body = $"Failed to start campaign up: {e.Message}"
+            };
+        }
+    }
+
 
     public async Task<APIGatewayProxyResponse> OnDisconnectHandler(APIGatewayProxyRequest request, ILambdaContext context)
     {
@@ -299,14 +468,29 @@ public class Functions
             var connection = await databaseClient.LoadAsync<GameConnection>(connectionId);
             await databaseClient.DeleteAsync(connection);
 
-            if (connection.GameSessionId != "not_inited")
+            if (connection.GameSessionId != "not_inited") //is connection in a game session?
             {
                 var gameSession = await databaseClient.LoadAsync<GameSession>(connection.GameSessionId);
+                Console.WriteLine($"Game Session = {gameSession}");
                 if (gameSession != null)
                 {
-                    gameSession.RemoveParticipant(connection.ConnectionId);
-                    await databaseClient.SaveAsync(gameSession);
-                    await BroadcastToConnectionAsync(gameSession, request, new ConnectionMessage("player-disconnected", connection));
+                    if (gameSession.Host.ConnectionId == connectionId)
+                    {
+                        context.Logger.LogInformation($"Host disconnected, deleting game session {gameSession.GameSessionId}");
+                        await databaseClient.DeleteAsync(gameSession);
+                        await BroadcastToConnectionAsync(gameSession, request, new ConnectionMessage("host-disconnected", connection));
+                        foreach(var participant in gameSession.Participants)
+                        {
+                            await databaseClient.DeleteAsync(participant);
+                        }
+                    }
+                    else
+                    {
+                        gameSession.RemoveParticipant(connection.ConnectionId);
+                        await databaseClient.SaveAsync(gameSession);
+                        await BroadcastToConnectionAsync(gameSession, request, new ConnectionMessage("player-disconnected", connection));
+                    }
+                    Console.WriteLine($"disconnect complete");
                 }
             }
             return new APIGatewayProxyResponse

--- a/gnome-party_backend/SocketService/aws-lambda-tools-defaults.json
+++ b/gnome-party_backend/SocketService/aws-lambda-tools-defaults.json
@@ -12,5 +12,5 @@
   "template": "serverless.template",
   "template-parameters": "\u0022ConnectionMappingTableName\u0022=\u0022ConnectionsTable\u0022;\u0022StageName\u0022=\u0022Prod\u0022",
   "s3-bucket": "gp-backend-bucket1",
-  "stack-name": "SocketServiceTemp"
+  "stack-name": "SocketService"
 }

--- a/gnome-party_backend/SocketService/serverless.template
+++ b/gnome-party_backend/SocketService/serverless.template
@@ -285,6 +285,123 @@
         }
       }
     },
+    "LobbyParticipantReadyFunction": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "SocketService::SocketService.Functions::LobbyParticipantReadyHandler",
+        "Runtime": "dotnet10",
+        "CodeUri": "",
+        "MemorySize": 512,
+        "Timeout": 30,
+        "Role": null,
+        "Policies": [
+          {
+            "DynamoDBCrudPolicy": {
+              "TableName": {
+                "Ref": "ConnectionMappingTableName"
+              }
+            }
+          },
+                    {
+            "DynamoDBCrudPolicy": {
+              "TableName": "GameTable"
+            }
+          },
+          {
+            "Statement": {
+              "Effect": "Allow",
+              "Action": "execute-api:ManageConnections",
+              "Resource": "arn:aws:execute-api:*:*:*/@connections/*"
+            }
+          }
+        ],
+        "Environment": {
+          "Variables": {
+            "TABLE_NAME": {
+              "Ref": "ConnectionMappingTableName"
+            }
+          }
+        }
+      }
+    },
+    "LobbyParticipantUnreadyFunction": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "SocketService::SocketService.Functions::LobbyParticipantUnreadyHandler",
+        "Runtime": "dotnet10",
+        "CodeUri": "",
+        "MemorySize": 512,
+        "Timeout": 30,
+        "Role": null,
+        "Policies": [
+          {
+            "DynamoDBCrudPolicy": {
+              "TableName": {
+                "Ref": "ConnectionMappingTableName"
+              }
+            }
+          },
+                    {
+            "DynamoDBCrudPolicy": {
+              "TableName": "GameTable"
+            }
+          },
+          {
+            "Statement": {
+              "Effect": "Allow",
+              "Action": "execute-api:ManageConnections",
+              "Resource": "arn:aws:execute-api:*:*:*/@connections/*"
+            }
+          }
+        ],
+        "Environment": {
+          "Variables": {
+            "TABLE_NAME": {
+              "Ref": "ConnectionMappingTableName"
+            }
+          }
+        }
+      }
+    },
+    "StartCampaignFunction": {
+      "Type": "AWS::Serverless::Function",
+      "Properties": {
+        "Handler": "SocketService::SocketService.Functions::StartCampaignHandler",
+        "Runtime": "dotnet10",
+        "CodeUri": "",
+        "MemorySize": 512,
+        "Timeout": 30,
+        "Role": null,
+        "Policies": [
+          {
+            "DynamoDBCrudPolicy": {
+              "TableName": {
+                "Ref": "ConnectionMappingTableName"
+              }
+            }
+          },
+                    {
+            "DynamoDBCrudPolicy": {
+              "TableName": "GameTable"
+            }
+          },
+          {
+            "Statement": {
+              "Effect": "Allow",
+              "Action": "execute-api:ManageConnections",
+              "Resource": "arn:aws:execute-api:*:*:*/@connections/*"
+            }
+          }
+        ],
+        "Environment": {
+          "Variables": {
+            "TABLE_NAME": {
+              "Ref": "ConnectionMappingTableName"
+            }
+          }
+        }
+      }
+    },
     "GPWebSocketApi": {
       "Type": "AWS::ApiGatewayV2::Api",
       "Properties": {
@@ -575,6 +692,147 @@
         }
       }
     },
+     "LobbyParticipantReadyRoute": {
+      "Type": "AWS::ApiGatewayV2::Route",
+      "Properties": {
+        "ApiId": {
+          "Ref": "GPWebSocketApi"
+        },
+        "RouteKey": "lobby-ready",
+        "AuthorizationType": "NONE",
+        "OperationName": "ConnectRoute",
+        "Target": {
+          "Fn::Join": [
+            "/",
+            [
+              "integrations",
+              {
+                "Ref": "LobbyParticipantReadyInteg"
+              }
+            ]
+          ]
+        }
+      }
+    },
+    "LobbyParticipantReadyInteg": {
+      "Type": "AWS::ApiGatewayV2::Integration",
+      "Properties": {
+        "ApiId": {
+          "Ref": "GPWebSocketApi"
+        },
+        "IntegrationType": "AWS_PROXY",
+        "IntegrationUri": {
+          "Fn::Sub": [
+            "arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${function}/invocations",
+            {
+              "region": {
+                "Ref": "AWS::Region"
+              },
+              "function": {
+                "Fn::GetAtt": [
+                  "LobbyParticipantReadyFunction",
+                  "Arn"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "LobbyParticipantUnreadyRoute": {
+      "Type": "AWS::ApiGatewayV2::Route",
+      "Properties": {
+        "ApiId": {
+          "Ref": "GPWebSocketApi"
+        },
+        "RouteKey": "lobby-unready",
+        "AuthorizationType": "NONE",
+        "OperationName": "ConnectRoute",
+        "Target": {
+          "Fn::Join": [
+            "/",
+            [
+              "integrations",
+              {
+                "Ref": "LobbyParticipantUnreadyInteg"
+              }
+            ]
+          ]
+        }
+      }
+    },
+    "LobbyParticipantUnreadyInteg": {
+      "Type": "AWS::ApiGatewayV2::Integration",
+      "Properties": {
+        "ApiId": {
+          "Ref": "GPWebSocketApi"
+        },
+        "IntegrationType": "AWS_PROXY",
+        "IntegrationUri": {
+          "Fn::Sub": [
+            "arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${function}/invocations",
+            {
+              "region": {
+                "Ref": "AWS::Region"
+              },
+              "function": {
+                "Fn::GetAtt": [
+                  "LobbyParticipantUnreadyFunction",
+                  "Arn"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+      "StartCampaignRoute": {
+      "Type": "AWS::ApiGatewayV2::Route",
+      "Properties": {
+        "ApiId": {
+          "Ref": "GPWebSocketApi"
+        },
+        "RouteKey": "start-campaign",
+        "AuthorizationType": "NONE",
+        "OperationName": "ConnectRoute",
+        "Target": {
+          "Fn::Join": [
+            "/",
+            [
+              "integrations",
+              {
+                "Ref": "StartCampaignInteg"
+              }
+            ]
+          ]
+        }
+      }
+    },
+    "StartCampaignInteg": {
+      "Type": "AWS::ApiGatewayV2::Integration",
+      "Properties": {
+        "ApiId": {
+          "Ref": "GPWebSocketApi"
+        },
+        "IntegrationType": "AWS_PROXY",
+        "IntegrationUri": {
+          "Fn::Sub": [
+            "arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/${function}/invocations",
+            {
+              "region": {
+                "Ref": "AWS::Region"
+              },
+              "function": {
+                "Fn::GetAtt": [
+                  "StartCampaignFunction",
+                  "Arn"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
     "Deployment": {
       "Type": "AWS::ApiGatewayV2::Deployment",
       "DependsOn": [
@@ -583,7 +841,10 @@
         "DisconnectRoute",
         "JoinGameSessionRoute",
         "HostGameSessionRoute",
-        "BeginCombatEncounterRoute"
+        "BeginCombatEncounterRoute",
+        "LobbyParticipantReadyRoute",
+        "LobbyParticipantUnreadyRoute",
+        "StartCampaignRoute"
       ],
       "Properties": {
         "ApiId": {
@@ -685,6 +946,48 @@
         "Action": "lambda:InvokeFunction",
         "FunctionName": {
           "Ref": "BeginCombatEncounterFunction"
+        },
+        "Principal": "apigateway.amazonaws.com"
+      }
+    },
+    "LobbyParticipantReadyPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "DependsOn": [
+        "LobbyParticipantReadyFunction",
+        "GPWebSocketApi"
+      ],
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "LobbyParticipantReadyFunction"
+        },
+        "Principal": "apigateway.amazonaws.com"
+      }
+    },
+    "LobbyParticipantUnreadyPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "DependsOn": [
+        "LobbyParticipantUnreadyFunction",
+        "GPWebSocketApi"
+      ],
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "LobbyParticipantUnreadyFunction"
+        },
+        "Principal": "apigateway.amazonaws.com"
+      }
+    },
+    "StartCampaignPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "DependsOn": [
+        "StartCampaignFunction",
+        "GPWebSocketApi"
+      ],
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Ref": "StartCampaignFunction"
         },
         "Principal": "apigateway.amazonaws.com"
       }


### PR DESCRIPTION
* refactor: host-game endpoint returns random 6 digit code

* fix: bad check for game with same invite code

* feat: join-game endpoint takes an invite code

* refactor: delete game sessions when host disconnects

* feat: lobby ready endpoint

* feat: lobby unready endpoint

* feat: start campaign endpoint

* refactor: Campaign Encounters can be more than just CombatEncounters

- previously encounters could only be CombatEncounters
- now encounters need to be subclasses of Encounter
- used AI to generate code that will serialize and deserialize the subclasses when working with dynamoDB
- all this work stemmed from making function that would init Encounters with our prewritten pools of options
- Now campaign Encounters not added to campaign until host calls "start-campaign" -

* refactor: parallelize output calls in JoinGameSessionHandler