### PR TITLE
feat: reworked encounter pools

### DIFF
--- a/gnome-party-frontend/host-view/scripts/action-animations/BlockAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/BlockAnimation.ts
@@ -36,7 +36,9 @@ class BlockAnimation implements AnimationStep
 		blockImg.src = "/img/BlockIcon.svg";
 		let blockIcon = new Konva.Image({
 			image: blockImg,
-			scale: {x: 0.2, y: 0.2},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 172,
+			height: 202,
 			opacity: 0.0
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/CripplingShotAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/CripplingShotAnimation.ts
@@ -45,7 +45,9 @@ class CripplingShotAnimation implements AnimationStep
 		noteImg.src = "/img/Arrow.svg";
 		let noteIcon = new Konva.Image({
 			image: noteImg,
-			scale: {x: 0.4, y: 0.4},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 108,
+			height: 29,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/DarkBoltAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/DarkBoltAnimation.ts
@@ -45,7 +45,9 @@ class DarkBoltAnimation implements AnimationStep
 		noteImg.src = "/img/Dark Bolt.svg";
 		let noteIcon = new Konva.Image({
 			image: noteImg,
-			scale: {x: 0.4, y: 0.4},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 159,
+			height: 73,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/DiscordAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/DiscordAnimation.ts
@@ -45,7 +45,9 @@ class DiscordAnimation implements AnimationStep
 		noteImg.src = "/img/Discord.svg";
 		let noteIcon = new Konva.Image({
 			image: noteImg,
-			scale: {x: 0.2, y: 0.2},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 86,
+			height: 91,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/EntangleAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/EntangleAnimation.ts
@@ -45,7 +45,9 @@ class EntangleAnimation implements AnimationStep
 		noteImg.src = "/img/Leaf Dart.svg";
 		let noteIcon = new Konva.Image({
 			image: noteImg,
-			scale: {x: 0.4, y: 0.4},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 37,
+			height: 97,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/FireballAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/FireballAnimation.ts
@@ -43,7 +43,9 @@ class FireballAnimation implements AnimationStep
 		noteImg.src = "/img/Fireball.svg";
 		let noteIcon = new Konva.Image({
 			image: noteImg,
-			scale: {x: 0.3, y: 0.3},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 159,
+			height: 73,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/IceRayAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/IceRayAnimation.ts
@@ -43,7 +43,9 @@ class IceRayAnimation implements AnimationStep
 		noteImg.src = "/img/Ice Ray.svg";
 		let noteIcon = new Konva.Image({
 			image: noteImg,
-			scale: {x: 0.3, y: 0.3},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 159,
+			height: 73,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/LeafDartAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/LeafDartAnimation.ts
@@ -47,7 +47,9 @@ class LeafDartAnimation implements AnimationStep
 			noteImg.src = "/img/Leaf Dart.svg";
 			let noteIcon = new Konva.Image({
 				image: noteImg,
-				scale: {x: 0.2, y: 0.2},
+				scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+				width: 97,
+				height: 37,
 				opacity: 0.0,
 			});
 	

--- a/gnome-party-frontend/host-view/scripts/action-animations/MagicMissileAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/MagicMissileAnimation.ts
@@ -45,7 +45,9 @@ class MagicMissileAnimation implements AnimationStep
 		noteImg.src = "/img/Magic Missile.svg";
 		let noteIcon = new Konva.Image({
 			image: noteImg,
-			scale: {x: 0.4, y: 0.4},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 159,
+			height: 27,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/MirrorAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/MirrorAnimation.ts
@@ -36,7 +36,9 @@ class MirrorAnimation implements AnimationStep
 		blockImg.src = "/img/Mirror.svg";
 		let blockIcon = new Konva.Image({
 			image: blockImg,
-			scale: {x: 0.2, y: 0.2},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 177,
+			height: 233,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/MockeryAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/MockeryAnimation.ts
@@ -47,7 +47,9 @@ class MockeryAnimation implements AnimationStep
 		noteImg.src = "/img/Mockery.svg";
 		let noteIcon = new Konva.Image({
 			image: noteImg,
-			scale: {x: 0.4, y: 0.4},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 202,
+			height: 208,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/ParryAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/ParryAnimation.ts
@@ -36,8 +36,10 @@ class ParryAnimation implements AnimationStep
 		blockImg.src = "/img/BlockIcon.svg";
 		let blockIcon = new Konva.Image({
 			image: blockImg,
-			scale: {x: 0.2, y: 0.2},
-			opacity: 0.0,
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 172,
+			height: 202,
+			opacity: 0.0
 		});
 
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/PiercingArrowAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/PiercingArrowAnimation.ts
@@ -45,7 +45,9 @@ class PiercingArrowAnimation implements AnimationStep
 		noteImg.src = "/img/Arrow.svg";
 		let noteIcon = new Konva.Image({
 			image: noteImg,
-			scale: {x: 0.4, y: 0.4},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 108,
+			height: 29,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/PowerChordAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/PowerChordAnimation.ts
@@ -80,7 +80,9 @@ class PowerChordAnimation implements AnimationStep
 				}
 				let noteIcon = new Konva.Image({
 					image: noteImg,
-					scale: {x: 0.2, y: 0.2},
+					scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+					width: 86,
+					height: 91,
 					opacity: 0.0
 				});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/PrimalRoarAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/PrimalRoarAnimation.ts
@@ -35,7 +35,9 @@ class PrimalRoarAnimation implements AnimationStep
 		roarImg.src = "/img/Roar.svg";
 		let roarIcon = new Konva.Image({
 			image: roarImg,
-			scale: {x: 0.75, y: 0.75},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 534,
+			height: 534,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/RattleGuardAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/RattleGuardAnimation.ts
@@ -35,7 +35,9 @@ class RattleGuardAnimation implements AnimationStep
 		blockImg.src = "/img/BlockIcon.svg";
 		let blockIcon = new Konva.Image({
 			image: blockImg,
-			scale: {x: 0.2, y: 0.2},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 173,
+			height: 202,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/RavenousGrowthAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/RavenousGrowthAnimation.ts
@@ -35,7 +35,9 @@ class RavenousGrowthAnimation implements AnimationStep
 		blockImg.src = "/img/GreenAura.svg";
 		let blockIcon = new Konva.Image({
 			image: blockImg,
-			scale: {x: 1.5, y: 1.5},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 791,
+			height: 190,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/SongAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/SongAnimation.ts
@@ -70,7 +70,9 @@ class SongAnimation implements AnimationStep
 		}
 		let noteIcon = new Konva.Image({
 			image: noteImg,
-			scale: {x: 0.2, y: 0.2},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 86,
+			height: 91,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/SonicSquealAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/SonicSquealAnimation.ts
@@ -35,7 +35,9 @@ class SonicSquealAnimation implements AnimationStep
 		roarImg.src = "/img/Roar.svg";
 		let roarIcon = new Konva.Image({
 			image: roarImg,
-			scale: {x: 0.75, y: 0.75},
+			scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+			width: 534,
+			height: 534,
 			opacity: 0.0,
 		});
 

--- a/gnome-party-frontend/host-view/scripts/action-animations/SoulDrainAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/SoulDrainAnimation.ts
@@ -52,7 +52,9 @@ class SoulDrainAnimation implements AnimationStep
 			noteImg.src = "/img/Soul Drain.svg";
 			let noteIcon = new Konva.Image({
 				image: noteImg,
-				scale: {x: 0.2, y: 0.2},
+				scale: {x: vm.getCombatPuppetScale(), y: vm.getCombatPuppetScale()},
+				width: 54,
+				height: 46,
 				opacity: 0.0,
 			});
 	

--- a/gnome-party-frontend/host-view/scripts/action-animations/SummonAnimation.ts
+++ b/gnome-party-frontend/host-view/scripts/action-animations/SummonAnimation.ts
@@ -70,7 +70,7 @@ class SummonAnimation implements AnimationStep
 					
 					console.log("i is ", (vm.enemyVisualComponents.size + 1));
 
-					vm.mainLayer.add(puppet);
+					vm.combatLayer.add(puppet);
 					// Create healthbar
 					let enemy = step.GameState.EnemyCharacters.find((c) => c.Id == e.params.SummonId);
 					if (enemy)

--- a/gnome-party-frontend/participant-view/components/ParticipantLobbyFlow.vue
+++ b/gnome-party-frontend/participant-view/components/ParticipantLobbyFlow.vue
@@ -9,7 +9,8 @@ type LobbyStep = "join" | "characterCreator" | "classSelect" | "waiting";
 const currentStep = ref<LobbyStep>("join");
 
 function onJoined() {
-    currentStep.value = "characterCreator";
+    // currentStep.value = "characterCreator";
+    currentStep.value = "classSelect";
 }
 
 function onCharacterReady() {

--- a/gnome-party_backend/Models/GameMetaData/Campaign.cs
+++ b/gnome-party_backend/Models/GameMetaData/Campaign.cs
@@ -1,5 +1,6 @@
 ﻿using Amazon.DynamoDBv2.DataModel;
 using Models.CharacterData;
+using Models.CharacterData.BossEnemyPoolClasses;
 using Models.CharacterData.DifficultEnemyPoolClasses;
 using Models.CharacterData.EasyEnemyPoolClasses;
 using Models.CombatData;
@@ -23,73 +24,74 @@ public class Campaign
     public void InitEncounters()
     {
         //Change later: right now every pool will have the same number of encounters included, but eventually we may want to have different numbers of encounters from each pool
-        int numberOfEncountersToIncludePerPool = 2;
+        int numberOfEncountersToIncludePerPool = 1;
         List<List<Encounter>> encounterPools = [
             // easy pool
             [
-                new CombatEncounter
-                {
-                    Enemies = [
-                        new GoblinArcher(),
-                        new GoblinArcher(),
-                    ]
-                },
-                new CombatEncounter
-                {
-                    Enemies = [
-                        new Skeleton(),
-                        new Skeleton(),
-                    ]
-                },
-                new CombatEncounter
-                {
-                    Enemies = [
-                        new Skeleton(),
-                        new GoblinArcher(),
-                    ]
-                },
-                new CombatEncounter
-                {
-                    Enemies = [
-                        new GnombieBrute(),
-                    ]
-                },
+                //new CombatEncounter
+                //{
+                //    Enemies = [
+                //        new GoblinArcher(),
+                //        new GoblinArcher(),
+                //    ]
+                //},
+                //new CombatEncounter
+                //{
+                //    Enemies = [
+                //        new Skeleton(),
+                //        new Skeleton(),
+                //    ]
+                //},
+                //new CombatEncounter
+                //{
+                //    Enemies = [
+                //        new Skeleton(),
+                //        new GoblinArcher(),
+                //    ]
+                //},
+                //new CombatEncounter
+                //{
+                //    Enemies = [
+                //        new GnombieBrute(),
+                //    ]
+                //},
                 
-                // Using less tested enemies
-                new CombatEncounter
-                {
-                    Enemies = [
-                        new GoblinArcher(),
-                        new ForestSprite(),
-                    ]
-                },
+                //// Using less tested enemies
+                //new CombatEncounter
+                //{
+                //    Enemies = [
+                //        new GoblinArcher(),
+                //        new ForestSprite(),
+                //    ]
+                //},
                 new CombatEncounter
                 {
                     Enemies = [
                         new CaveBat(),
                         new Skeleton(),
                         new CaveBat(),
+                        new ForestSprite(),
                     ]
                 }
 
             ],
             // medium pool
             [
-                new CombatEncounter
-                {
-                    Enemies = [
-                        new Skeleton(),
-                        new GnombieBrute(),
-                        new Skeleton(),
-                    ]
-                },
-                new CombatEncounter
-                {
-                    Enemies = [
-                        new GnombieBrute(),
-                        new GnombieBrute(),
-                    ]
-                },
+                //new CombatEncounter
+                //{
+                //    Enemies = [
+                //        new Skeleton(),
+                //        new GnombieBrute(),
+                //        new Skeleton(),
+                //    ]
+                //},
+                //new CombatEncounter
+                //{
+                //    Enemies = [
+                //        new GnombieBrute(),
+                //        new GnombieBrute(),
+                //    ]
+                //},
                 new CombatEncounter
                 {
                     Enemies = [
@@ -97,37 +99,47 @@ public class Campaign
                         new Skeleton(),
                         new Skeleton(),
                         new GoblinArcher(),
+                        new GnombieBrute(),
                     ]
                 },
 
-                // Using less tested enemies
+                //// Using less tested enemies
+                //new CombatEncounter
+                //{
+                //    Enemies = [
+                //        new GoblinArcher(),
+                //        new ForestSprite(),
+                //        new GoblinArcher(),
+                //    ]
+                //},
+                //new CombatEncounter
+                //{
+                //    Enemies = [
+                //        new CaveBat(),
+                //        new Skeleton()
+                //        {
+                //            Health = 40,
+                //            MaxHealth = 40,
+                //        },
+                //        new CaveBat(),
+                //    ]
+                //},
+                //new CombatEncounter
+                //{
+                //    Enemies = [
+                //        new CaveBat(),
+                //        new CaveBat(),
+                //        new CaveBat(),
+                //        new CaveBat(),
+                //    ]
+                //}
+            ],
+            // boss pool
+            [
                 new CombatEncounter
                 {
                     Enemies = [
-                        new GoblinArcher(),
-                        new ForestSprite(),
-                        new GoblinArcher(),
-                    ]
-                },
-                new CombatEncounter
-                {
-                    Enemies = [
-                        new CaveBat(),
-                        new Skeleton()
-                        {
-                            Health = 40,
-                            MaxHealth = 40,
-                        },
-                        new CaveBat(),
-                    ]
-                },
-                new CombatEncounter
-                {
-                    Enemies = [
-                        new CaveBat(),
-                        new CaveBat(),
-                        new CaveBat(),
-                        new CaveBat(),
+                        new GnomeEater()
                     ]
                 }
             ]

--- a/gnome-party_backend/Models/GameMetaData/Campaign.cs
+++ b/gnome-party_backend/Models/GameMetaData/Campaign.cs
@@ -30,22 +30,104 @@ public class Campaign
                 new CombatEncounter
                 {
                     Enemies = [
+                        new GoblinArcher(),
+                        new GoblinArcher(),
+                    ]
+                },
+                new CombatEncounter
+                {
+                    Enemies = [
+                        new Skeleton(),
+                        new Skeleton(),
+                    ]
+                },
+                new CombatEncounter
+                {
+                    Enemies = [
                         new Skeleton(),
                         new GoblinArcher(),
+                    ]
+                },
+                new CombatEncounter
+                {
+                    Enemies = [
                         new GnombieBrute(),
                     ]
                 },
+                
+                // Using less tested enemies
+                new CombatEncounter
+                {
+                    Enemies = [
+                        new GoblinArcher(),
+                        new ForestSprite(),
+                    ]
+                },
+                new CombatEncounter
+                {
+                    Enemies = [
+                        new CaveBat(),
+                        new Skeleton(),
+                        new CaveBat(),
+                    ]
+                }
+
             ],
             // medium pool
             [
                 new CombatEncounter
                 {
                     Enemies = [
+                        new Skeleton(),
+                        new GnombieBrute(),
+                        new Skeleton(),
+                    ]
+                },
+                new CombatEncounter
+                {
+                    Enemies = [
+                        new GnombieBrute(),
+                        new GnombieBrute(),
+                    ]
+                },
+                new CombatEncounter
+                {
+                    Enemies = [
+                        new GoblinArcher(),
+                        new Skeleton(),
+                        new Skeleton(),
+                        new GoblinArcher(),
+                    ]
+                },
+
+                // Using less tested enemies
+                new CombatEncounter
+                {
+                    Enemies = [
+                        new GoblinArcher(),
+                        new ForestSprite(),
+                        new GoblinArcher(),
+                    ]
+                },
+                new CombatEncounter
+                {
+                    Enemies = [
+                        new CaveBat(),
                         new Skeleton()
                         {
-                            Health = 15,
-                            MaxHealth = 15,
-                        }
+                            Health = 40,
+                            MaxHealth = 40,
+                        },
+                        new CaveBat(),
+                    ]
+                },
+                new CombatEncounter
+                {
+                    Enemies = [
+                        new CaveBat(),
+                        new CaveBat(),
+                        new CaveBat(),
+                        new CaveBat(),
                     ]
                 }
             ]


### PR DESCRIPTION
I separated any encounters that used enemies aside from Goblin Archer, Skeleton, and Gnombie Brute from the rest of the encounters within its pool. I'd like to see if these ones work, but it should be quick to get rid of them if they do not